### PR TITLE
[add]nginx設定ファイルの初期化とHTTPSを実装

### DIFF
--- a/.ebextensions/nginx/nginx.conf
+++ b/.ebextensions/nginx/nginx.conf
@@ -1,0 +1,54 @@
+user  nginx;
+worker_processes  auto;
+error_log  /var/log/nginx/error.log;
+pid        /var/run/nginx.pid;
+worker_rlimit_nofile    32634;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    access_log    /var/log/nginx/access.log;
+
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                          '$status $body_bytes_sent "$http_referer" '
+                          '"$http_user_agent" "$http_x_forwarded_for"';
+
+    include  conf.d/*.conf;
+
+    map $http_upgrade $connection_upgrade {
+            default       "upgrade";
+    }
+
+    server {
+        listen 80 default_server;
+        if ($http_x_forwarded_proto = 'http'){
+        return 301 https://$host$request_uri;
+        }
+        gzip on;
+        gzip_comp_level 4;
+        gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+
+        access_log    /var/log/nginx/access.log main;
+
+        location / {
+            proxy_pass            http://docker;
+            proxy_http_version    1.1;
+
+            proxy_set_header    Connection             $connection_upgrade;
+            proxy_set_header    Upgrade                $http_upgrade;
+            proxy_set_header    Host                   $host;
+            proxy_set_header    X-Real-IP              $remote_addr;
+            proxy_set_header    X-Forwarded-For        $proxy_add_x_forwarded_for;
+        }
+
+        # Include the Elastic Beanstalk generated locations
+        include conf.d/elasticbeanstalk/*.conf;
+        include conf.d/elasticbeanstalk/*.conf;
+    }
+}


### PR DESCRIPTION
nginx初期化を行い、その設定ファイル内でHTTPS接続を行う設定を実装する。
これによってコンテナが再起動した際も設定が存続（同じ設定で起動）することができる。
