### PR TITLE
[update]Dorckerrunファイルの変更とそれに伴うDockerfileの変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ EXPOSE 80
 ENV CURRENT_ENVIRONMENT=production
 ENV CAKEPHP_DEBUG=0
 
-# 鍵の環境変数（AWS上での操作による設定に切り替える可能性）
+# 鍵の環境変数
 ENV DEV_KEY=HOGEhogeHOGEhogeHOGEhogeHOGEhoge
 
 # MySQL用の環境変数
@@ -38,7 +38,6 @@ WORKDIR /var/www/html/mycakeapp
 # アプリケーションファイルを追加
 ADD html/ /var/www/html
 # 設定ファイルを追加
-ADD docker/nginx/default.conf /var/www/docker/nginx/default.conf
 ADD docker/php/php.ini /var/www/docker/php/php.ini
 
 ENV APACHE_DOCUMENT_ROOT /var/www/html/mycakeapp/webroot

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -1,8 +1,14 @@
 {
   "AWSEBDockerrunVersion": "1",
-  "Logging": "/var/log/nginx",
   "Image": {
     "Name": "887028440782.dkr.ecr.ap-northeast-1.amazonaws.com/quelcinemas_ecr_repos:latest",
     "Update": "true"
-  }
+  },
+  "Ports": [
+    {
+      "ContainerPort": 80
+    }
+  ],
+  "Logging": "/var/log/nginx",
+  "Entrypoint": "var/www/html/mycakeapp"
 }


### PR DESCRIPTION
Port番号の指定が必要

```
[Instance: i-051b428ef70e1f6a8] Command failed on instance. Return code: 1 Output: Engine execution has encountered an error..

Instance deployment: You must specify the 'Ports' key when you specify the 'Image' key in 'Dockerrun.aws.json'. The deployment failed.
2021-01-16 12:26:12 UTC+0900 | INFO

Create environment operation is complete, but with errors. For more information, see troubleshooting documentation.
```
