### PR TITLE
[update]Dockerrunファイルを修正

### DIFF
--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -10,5 +10,4 @@
     }
   ],
   "Logging": "/var/log/nginx",
-  "Entrypoint": "var/www/html/mycakeapp"
 }


### PR DESCRIPTION
エントリーポイントを指定した結果、ビルド時に
```
An error occurred during execution of command [app-deploy] - [Run Docker Container]. Stop running the command. Error: failed to run docker container: Command /bin/sh -c docker run -d --env-file /opt/elasticbeanstalk/deployment/env.list -v /var/log/eb-docker/containers/eb-current-app:/var/log/nginx --entrypoint var/www/html/mycakeapp 601c54eb7800  failed with error exit status 127. Stderr:docker: Error response from daemon: OCI runtime create failed: container_linux.go:370: starting container process caused: exec: "var/www/html/mycakeapp": stat var/www/html/mycakeapp: no such file or directory: unknown.
 ```
が表示されたため修正