### PR TITLE
[update]aws-sdk-phpをインストールするためにDockerfileを編集

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,3 +46,4 @@ RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf
 
 # composerのインストールを行う
 RUN composer install
+RUN composer require aws/aws-sdk-php


### PR DESCRIPTION
Dockerfileで
`RUN composer require aws/aws-sdk-php`
を追加。